### PR TITLE
Fix Merkle proof encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,69 @@ You can also use the web interface at `/` instead of calling the endpoints manua
 This project is a minimal skeleton and does not implement advanced features such
 as user permissions, searching by object labels or a production-ready auth
 system. It can be extended to meet specific company requirements.
+
+## Reward Distribution Contract
+
+The `contracts/RewardDistributor.sol` smart contract allows users to
+withdraw rewards that are published off-chain via a Merkle root. Each
+day you recompute cumulative balances for all users, generate a new
+root and call `setMerkleRoot` with it. Users prove their balance using a
+Merkle proof when calling `withdraw`.
+
+Helper scripts are provided to publish a new Merkle root. You can use the
+Python script `scripts/generate_merkle.py` or the Node version
+`scripts/generateMerkle.js`. Both read a JSON mapping of addresses to
+cumulative amounts and produce `proofs.json`.
+
+Python usage:
+
+```bash
+pip install eth-hash
+python scripts/generate_merkle.py balances.json
+```
+
+Node usage (also pushes the root on-chain if parameters are given):
+
+```bash
+npm install
+node scripts/generateMerkle.js balances.json <contract> <ownerKey> <rpcUrl>
+```
+
+Deploy `RewardDistributor.sol` passing the ERC20 token used for rewards
+(for example the USDC token address on Polygon).
+Only the owner can update the root. Users can withdraw at any time with
+proofs corresponding to the latest root.
+
+### Generating a proof
+
+`generate_merkle.py` now also creates a `proofs.json` file that stores the
+Merkle proof for each address alongside the cumulative amount. Run the script
+with your balances file:
+
+```bash
+python scripts/generate_merkle.py balances.json
+```
+
+The command prints the Merkle root and writes `proofs.json` in the same
+directory.
+
+### Sending a withdraw transaction
+
+Load the user's proof from `proofs.json` and call `withdraw` using the helper
+script:
+
+```bash
+node scripts/withdraw.js proofs.json <contract> <userKey> <rpcUrl>
+```
+
+Internally it performs the equivalent of:
+
+```javascript
+const proofs = require('./proofs.json');
+const distributor = new ethers.Contract(address, RewardDistributorAbi, signer);
+const { amount, proof } = proofs[signer.address.toLowerCase()];
+await distributor.withdraw(amount, proof);
+```
+
+`signer` is the connected wallet (for example MetaMask). The contract verifies
+the proof and transfers the pending rewards.

--- a/contracts/RewardDistributor.sol
+++ b/contracts/RewardDistributor.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+/// @title RewardDistributor
+/// @notice Users can withdraw rewards proved by a Merkle root of cumulative balances.
+contract RewardDistributor is Ownable {
+    IERC20 public immutable rewardToken;
+    bytes32 public merkleRoot;
+    mapping(address => uint256) public claimed;
+
+    event RootUpdated(bytes32 root);
+    event Withdraw(address indexed user, uint256 amount);
+
+    constructor(IERC20 _token) Ownable(msg.sender) {
+        rewardToken = _token;
+    }
+
+    /// @notice Owner updates the Merkle root representing cumulative user balances.
+    function setMerkleRoot(bytes32 _root) external onlyOwner {
+        merkleRoot = _root;
+        emit RootUpdated(_root);
+    }
+
+    /// @notice Withdraw available rewards by providing a valid Merkle proof.
+    /// @param cumulativeAmount Total reward earned so far for the caller.
+    /// @param proof Merkle proof showing caller and amount are part of the root.
+    function withdraw(uint256 cumulativeAmount, bytes32[] calldata proof) external {
+        bytes32 leaf = keccak256(abi.encode(msg.sender, cumulativeAmount));
+        require(MerkleProof.verify(proof, merkleRoot, leaf), "Invalid proof");
+        uint256 alreadyClaimed = claimed[msg.sender];
+        require(cumulativeAmount > alreadyClaimed, "Nothing to claim");
+        uint256 claimable = cumulativeAmount - alreadyClaimed;
+        claimed[msg.sender] = cumulativeAmount;
+        require(rewardToken.transfer(msg.sender, claimable), "Transfer failed");
+        emit Withdraw(msg.sender, claimable);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "reward-distributor",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "ethers": "^5.7.2",
+    "merkletreejs": "^0.2.34",
+    "keccak256": "^1.0.6"
+  }
+}

--- a/scripts/generateMerkle.js
+++ b/scripts/generateMerkle.js
@@ -1,0 +1,61 @@
+const ethersMod = require('ethers');
+const ethers = ethersMod.ethers ? ethersMod.ethers : ethersMod;
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+const fs = require('fs');
+
+function abiEncode(types, values) {
+  if (ethers.utils && ethers.utils.defaultAbiCoder) {
+    return ethers.utils.defaultAbiCoder.encode(types, values);
+  }
+  const coder = ethers.AbiCoder && ethers.AbiCoder.defaultAbiCoder
+    ? ethers.AbiCoder.defaultAbiCoder()
+    : new ethers.AbiCoder();
+  return coder.encode(types, values);
+}
+
+function leafHash(addr, amount) {
+  const encoded = abiEncode(['address', 'uint256'], [addr, amount]);
+  if (ethers.utils && ethers.utils.keccak256) {
+    return ethers.utils.keccak256(encoded);
+  }
+  return ethers.keccak256(encoded);
+}
+
+async function main() {
+  const [balancesPath, contractAddress, ownerKey, rpcUrl] = process.argv.slice(2);
+  if (!balancesPath) {
+    console.log('Usage: node generateMerkle.js <balances.json> [contractAddress ownerKey rpcUrl]');
+    return;
+  }
+
+  const data = JSON.parse(fs.readFileSync(balancesPath));
+  const addresses = Object.keys(data);
+  const leaves = addresses.map(addr => leafHash(addr, data[addr]));
+  const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
+  const root = tree.getHexRoot();
+
+  const proofs = {};
+  addresses.forEach((addr, i) => {
+    proofs[addr.toLowerCase()] = {
+      amount: parseInt(data[addr]),
+      proof: tree.getHexProof(leaves[i])
+    };
+  });
+
+  fs.writeFileSync('proofs.json', JSON.stringify({ root, proofs }, null, 2));
+  console.log('Merkle root:', root);
+  console.log('Proofs written to proofs.json');
+
+  if (contractAddress && ownerKey && rpcUrl) {
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    const wallet = new ethers.Wallet(ownerKey, provider);
+    const abi = ['function setMerkleRoot(bytes32)'];
+    const distributor = new ethers.Contract(contractAddress, abi, wallet);
+    const tx = await distributor.setMerkleRoot(root);
+    await tx.wait();
+    console.log('Root updated on-chain:', tx.hash);
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/generate_merkle.py
+++ b/scripts/generate_merkle.py
@@ -1,0 +1,62 @@
+import json
+import sys
+from typing import List, Dict
+from eth_hash.auto import keccak
+
+
+def keccak_hex(data: bytes) -> bytes:
+    return keccak(data)
+
+
+def build_tree(leaves: List[bytes]) -> List[List[bytes]]:
+    """Return a list of levels, bottom (leaves) first."""
+    tree = [leaves]
+    level = leaves
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level = level + [level[-1]]
+        level = [keccak_hex(level[i] + level[i + 1]) for i in range(0, len(level), 2)]
+        tree.append(level)
+    return tree
+
+
+def get_proof(tree: List[List[bytes]], index: int) -> List[bytes]:
+    proof = []
+    for level in tree[:-1]:
+        if len(level) % 2 == 1:
+            level = level + [level[-1]]
+        pair_index = index ^ 1
+        proof.append(level[pair_index])
+        index //= 2
+    return proof
+
+
+def main():
+    """Generate Merkle root from a JSON mapping of address to cumulative amount."""
+    if len(sys.argv) != 2:
+        print("Usage: generate_merkle.py <balances.json>")
+        return
+    data = json.load(open(sys.argv[1]))
+    addresses = list(data.keys())
+    leaves = []
+    for addr, amount in data.items():
+        addr_bytes = bytes.fromhex(addr[2:])
+        padded = b"\x00" * 12 + addr_bytes
+        leaves.append(keccak_hex(padded + int(amount).to_bytes(32, "big")))
+    tree = build_tree(leaves)
+    root = tree[-1][0]
+    proofs: Dict[str, Dict[str, object]] = {}
+    for idx, addr in enumerate(addresses):
+        proof = [p.hex() for p in get_proof(tree, idx)]
+        proofs[addr.lower()] = {
+            "amount": int(data[addr]),
+            "proof": proof,
+        }
+    out = {"root": root.hex(), "proofs": proofs}
+    json.dump(out, open("proofs.json", "w"), indent=2)
+    print("Merkle root:", root.hex())
+    print("Proofs written to proofs.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -1,0 +1,26 @@
+const ethersMod = require('ethers');
+const ethers = ethersMod.ethers ? ethersMod.ethers : ethersMod;
+const fs = require('fs');
+
+async function main() {
+  const [proofsPath, contractAddress, userKey, rpcUrl] = process.argv.slice(2);
+  if (!proofsPath || !contractAddress || !userKey || !rpcUrl) {
+    console.log('Usage: node withdraw.js <proofs.json> <contractAddress> <userPrivateKey> <rpcUrl>');
+    return;
+  }
+
+  const proofsFile = JSON.parse(fs.readFileSync(proofsPath));
+  const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(userKey, provider);
+  const info = proofsFile.proofs[wallet.address.toLowerCase()];
+  if (!info) {
+    throw new Error('No proof for this address');
+  }
+  const abi = ['function withdraw(uint256, bytes32[])'];
+  const distributor = new ethers.Contract(contractAddress, abi, wallet);
+  const tx = await distributor.withdraw(info.amount, info.proof);
+  await tx.wait();
+  console.log('Withdraw tx hash:', tx.hash);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- compute leaves using `abi.encode` so proofs match the contract
- update Python and Node helper scripts accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866778edbd083339db9cd9d3b858ca2